### PR TITLE
add signing via openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,15 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = [ ]
+sign = [ "openssl" ]
+
 [[example]]
 name = "generate-regdb"
 
 [dependencies]
 anyhow = "1"
 byteorder = "1.3"
+
+openssl = { version = "0.10", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,14 @@ impl RegDB {
 
         Ok(ret)
     }
+
+    /// Create a new empty Regulatory DB
+    pub fn new() -> Self {
+        Self {
+            wmm_rules: HashMap::new(),
+            countries: HashMap::new(),
+        }
+    }
 }
 
 const WMMRULE_ITEMS: [&str; 8] = [


### PR DESCRIPTION
This adds signing the database via openssl to the Binary struct.
This also changes the Binary Struct to a `Vec<u8>` to cache the conversion to binary. This is not a breaking change, as all fields where private before.